### PR TITLE
fix: Update npm publish & docker workflow triggers

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,9 +1,8 @@
 name: Publish to Docker Hub
 
 on:
-  push:
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,11 +1,8 @@
 name: Publish to npm
 
 on:
-  push:
-    branches:
-      - main
-    tags:
-      - "v*"
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
Updates the npm & docker publish workflow to only trigger on releases created by Release Please, while keeping manual trigger option.